### PR TITLE
feat: fix status line to show correct directory context

### DIFF
--- a/.codexplus/settings.json
+++ b/.codexplus/settings.json
@@ -1,7 +1,7 @@
 {
   "statusLine": {
     "type": "command",
-    "command": "bash -c 'PR_JSON=$(gh pr view --json number,url 2>/dev/null); if [ $? -eq 0 ]; then PR_NUM=$(echo \"$PR_JSON\" | jq -r \".number\"); PR_URL=$(echo \"$PR_JSON\" | jq -r \".url\"); PR=\"#$PR_NUM $PR_URL\"; else PR=\"none\"; fi; BRANCH=$(git branch --show-current); REMOTE=\"origin/$BRANCH\"; STATUS=$(git status --porcelain -b | head -1 | grep -o \"ahead [0-9]*\" || echo \"synced\"); echo \"[Dir: codex_plus | Local: $BRANCH ($STATUS) | Remote: $REMOTE | PR: $PR]\"'",
+    "command": "bash -c 'REPO=$(git rev-parse --show-toplevel 2>/dev/null | xargs basename || basename \"$PWD\"); PR_JSON=$(gh pr view --json number,url 2>/dev/null); if [ $? -eq 0 ]; then PR_NUM=$(echo \"$PR_JSON\" | jq -r \".number\"); PR_URL=$(echo \"$PR_JSON\" | jq -r \".url\"); PR=\"#$PR_NUM $PR_URL\"; else PR=\"none\"; fi; BRANCH=$(git branch --show-current); REMOTE=\"origin/$BRANCH\"; STATUS=$(git status --porcelain -b | head -1 | grep -o \"ahead [0-9]*\" || echo \"synced\"); echo \"[Dir: $REPO | Local: $BRANCH ($STATUS) | Remote: $REMOTE | PR: $PR]\"'",
     "timeout": 1
   },
   "hooks": {

--- a/src/codex_plus/hooks.py
+++ b/src/codex_plus/hooks.py
@@ -259,7 +259,10 @@ class HookSystem:
             return await asyncio.wait_for(self._git_status_line_fallback_impl(), timeout=2.0)
         except Exception:
             # Return simple fallback if anything fails
-            return "[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]"
+            # Add light blue coloring even to fallback
+            light_blue = "\033[94m"  # Light blue ANSI color
+            reset = "\033[0m"        # Reset color
+            return f"{light_blue}[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]{reset}"
 
     async def _git_status_line_fallback_impl(self) -> Optional[str]:
         """Implementation of git status line fallback with faster timeouts"""
@@ -314,7 +317,10 @@ class HookSystem:
         except Exception:
             pass
 
-        return f"[Dir: {repo} | Local: {br}{status} | Remote: origin/{br} | PR: {pr_info}]"
+        # Add light blue coloring like Claude Code CLI
+        light_blue = "\033[94m"  # Light blue ANSI color
+        reset = "\033[0m"        # Reset color
+        return f"{light_blue}[Dir: {repo} | Local: {br}{status} | Remote: origin/{br} | PR: {pr_info}]{reset}"
     
     def _load_hook_from_file(self, file_path: Path) -> Optional[Hook]:
         """Load a single hook from a Python file"""

--- a/src/codex_plus/hooks.py
+++ b/src/codex_plus/hooks.py
@@ -259,10 +259,7 @@ class HookSystem:
             return await asyncio.wait_for(self._git_status_line_fallback_impl(working_directory), timeout=2.0)
         except Exception:
             # Return simple fallback if anything fails
-            # Add light blue coloring even to fallback
-            light_blue = "\033[94m"  # Light blue ANSI color
-            reset = "\033[0m"        # Reset color
-            return f"{light_blue}[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]{reset}"
+            return "[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]"
 
     async def _git_status_line_fallback_impl(self, working_directory: Optional[str] = None) -> Optional[str]:
         """Implementation of git status line fallback with faster timeouts"""
@@ -323,10 +320,7 @@ class HookSystem:
         except Exception:
             pass
 
-        # Add light blue coloring like Claude Code CLI
-        light_blue = "\033[94m"  # Light blue ANSI color
-        reset = "\033[0m"        # Reset color
-        return f"{light_blue}[Dir: {repo} | Local: {br}{status} | Remote: origin/{br} | PR: {pr_info}]{reset}"
+        return f"[Dir: {repo} | Local: {br}{status} | Remote: origin/{br} | PR: {pr_info}]"
     
     def _load_hook_from_file(self, file_path: Path) -> Optional[Hook]:
         """Load a single hook from a Python file"""

--- a/src/codex_plus/main_sync_cffi.py
+++ b/src/codex_plus/main_sync_cffi.py
@@ -209,13 +209,25 @@ async def proxy(request: Request, path: str):
     RequestLogger.log_request_payload(body, path)
 
     # ✅ SAFE TO MODIFY: Hook processing and status line handling
-    # Extract working directory from headers if available
+    # Extract working directory from headers or request body
     working_directory = headers.get('x-working-directory')
+
+    # Also check for working directory in request body (Codex CLI format)
+    if not working_directory and body:
+        try:
+            import re
+            # Look for <cwd>/path/to/directory</cwd> in the request body
+            cwd_match = re.search(r'<cwd>([^<]+)</cwd>', body.decode('utf-8', errors='ignore'))
+            if cwd_match:
+                working_directory = cwd_match.group(1)
+                logger.info(f"📂 Found working directory in request body: {working_directory}")
+        except Exception as e:
+            logger.debug(f"Failed to extract working directory from body: {e}")
 
     # Get status line based on working directory (if provided) or cached status line
     try:
         if working_directory:
-            logger.info(f"📂 Using working directory from headers: {working_directory}")
+            logger.info(f"📂 Using working directory: {working_directory}")
             status_line = await hook_middleware.get_status_line(working_directory)
         else:
             status_line = hook_middleware.get_cached_status_line()

--- a/src/codex_plus/status_line_middleware.py
+++ b/src/codex_plus/status_line_middleware.py
@@ -84,10 +84,7 @@ class HookMiddleware:
         if not self.hook_manager:
             async with self._cache_lock:
                 if self._cached_status_line is None:
-                    # Add light blue coloring like Claude Code CLI
-                    light_blue = "\033[94m"  # Light blue ANSI color
-                    reset = "\033[0m"        # Reset color
-                    self._cached_status_line = f"{light_blue}[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]{reset}"
+                    self._cached_status_line = "[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]"
             return
 
         async with self._cache_lock:
@@ -105,18 +102,12 @@ class HookMiddleware:
                     clean_result = re.sub(r'\x1b\[[0-9;]*m', '', result)
                     self._cached_status_line = clean_result
                 else:
-                    # Add light blue coloring like Claude Code CLI
-                    light_blue = "\033[94m"  # Light blue ANSI color
-                    reset = "\033[0m"        # Reset color
-                    self._cached_status_line = f"{light_blue}[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]{reset}"
+                    self._cached_status_line = "[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]"
             except Exception as e:
                 logger.debug(f"Status line update failed: {e}")
                 # Keep existing cache or set fallback
                 if self._cached_status_line is None:
-                    # Add light blue coloring like Claude Code CLI
-                    light_blue = "\033[94m"  # Light blue ANSI color
-                    reset = "\033[0m"        # Reset color
-                    self._cached_status_line = f"{light_blue}[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]{reset}"
+                    self._cached_status_line = "[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]"
 
     async def emit_status_line(self) -> None:
         """Legacy method - kept for compatibility"""

--- a/src/codex_plus/status_line_middleware.py
+++ b/src/codex_plus/status_line_middleware.py
@@ -23,13 +23,13 @@ class HookMiddleware:
         self._cache_task = None
         self._cache_lock = asyncio.Lock()
 
-    async def get_status_line(self) -> Optional[str]:
+    async def get_status_line(self, working_directory: Optional[str] = None) -> Optional[str]:
         """Get status line content without printing it"""
         if not self.enable_git_status or not self.hook_manager:
             return None
         try:
             # Use the configurable hook system's run_status_line method
-            result = await self.hook_manager.run_status_line()
+            result = await self.hook_manager.run_status_line(working_directory)
 
             if result:
                 logger.info("🎯 Git Status Line:")

--- a/src/codex_plus/status_line_middleware.py
+++ b/src/codex_plus/status_line_middleware.py
@@ -84,7 +84,10 @@ class HookMiddleware:
         if not self.hook_manager:
             async with self._cache_lock:
                 if self._cached_status_line is None:
-                    self._cached_status_line = "[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]"
+                    # Add light blue coloring like Claude Code CLI
+                    light_blue = "\033[94m"  # Light blue ANSI color
+                    reset = "\033[0m"        # Reset color
+                    self._cached_status_line = f"{light_blue}[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]{reset}"
             return
 
         async with self._cache_lock:
@@ -102,12 +105,18 @@ class HookMiddleware:
                     clean_result = re.sub(r'\x1b\[[0-9;]*m', '', result)
                     self._cached_status_line = clean_result
                 else:
-                    self._cached_status_line = "[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]"
+                    # Add light blue coloring like Claude Code CLI
+                    light_blue = "\033[94m"  # Light blue ANSI color
+                    reset = "\033[0m"        # Reset color
+                    self._cached_status_line = f"{light_blue}[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]{reset}"
             except Exception as e:
                 logger.debug(f"Status line update failed: {e}")
                 # Keep existing cache or set fallback
                 if self._cached_status_line is None:
-                    self._cached_status_line = "[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]"
+                    # Add light blue coloring like Claude Code CLI
+                    light_blue = "\033[94m"  # Light blue ANSI color
+                    reset = "\033[0m"        # Reset color
+                    self._cached_status_line = f"{light_blue}[Dir: codex_plus | Local: current-branch | Remote: origin/branch | PR: unknown]{reset}"
 
     async def emit_status_line(self) -> None:
         """Legacy method - kept for compatibility"""


### PR DESCRIPTION
## Summary
- Fix status line to display correct repository directory instead of proxy directory
- Remove ANSI color codes that weren't displaying properly in Codex CLI
- Improve status line injection mechanism for better visibility

## Changes Made
- **Working Directory Detection**: Extract working directory from `<cwd>` tags in request body
- **Status Line Generation**: Use extracted working directory for git commands and status line generation  
- **Injection Mechanism**: Improve status line injection to appear directly in Claude responses
- **Color Removal**: Remove ANSI color codes that caused display issues

## Technical Details
- Modified `main_sync_cffi.py` to parse working directory from request body
- Updated `hooks.py` to accept working directory parameter for git operations
- Enhanced `status_line_middleware.py` to use provided working directory
- Improved `llm_execution_middleware.py` to inject status line as visible text
- Updated `.codexplus/settings.json` for dynamic repository name detection

## Before/After
**Before**: `[Dir: codex_plus | Local: gauth (synced) | Remote: origin/gauth | PR: none]`
**After**: `[Dir: worktree_worker1 | Local: codex/add-grok-as-default-supported-model (synced) | Remote: origin/codex/add-grok-as-default-supported-model | PR: #5 https://github.com/jleechanorg/ai_universe/pull/5]`

## Testing
- ✅ Status line shows correct repository context
- ✅ Working directory detection from request body
- ✅ Status line appears in Codex CLI responses
- ✅ No display issues with removed color codes