### PR TITLE
Fix macOS mktemp compatibility in integrate.sh

### DIFF
--- a/integrate.sh
+++ b/integrate.sh
@@ -240,7 +240,7 @@ echo -e "${GREEN}🔄 Starting integration process...${NC}"
 
 # Fetch latest changes from origin/main first to ensure accurate comparisons
 echo "📡 Fetching latest changes from origin/main..."
-err_file="$(mktemp -t integrate_fetch_err.XXXXXX)"
+err_file="$(mktemp)"
 if ! GIT_TERMINAL_PROMPT=0 git fetch --prune origin main 2>"$err_file"; then
     echo "❌ Error: Failed to fetch updates from origin/main."
     echo "   Possible causes: network issues, authentication problems, or repository unavailability."


### PR DESCRIPTION
## Summary
Fix macOS mktemp compatibility issue in integrate.sh by removing the suffix pattern that causes literal file creation instead of unique temporary files.

## Changes
- Remove `-t integrate_fetch_err.XXXXXX` suffix from mktemp call in integrate.sh:243
- Use plain `mktemp` for cross-platform compatibility

## Issue Description
The pattern `mktemp -t integrate_fetch_err.XXXXXX` was creating literal `XXXXXX` files on macOS instead of unique temporary files, causing integration script failures.

## Test Plan
- [x] Verify the script runs without creating literal XXXXXX files
- [ ] Test on both macOS and Linux systems
- [ ] Ensure temporary files are properly created and cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `mktemp -t integrate_fetch_err.XXXXXX` with plain `mktemp` for cross-platform temporary error file creation during `git fetch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e743759dcc8a5e6e091375fb000b844194571194. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->