### PR TITLE
fix(proxy): ensure provider display works on older bash

### DIFF
--- a/proxy.sh
+++ b/proxy.sh
@@ -150,7 +150,8 @@ print_status() {
                 local provider
                 provider=$(cat "$RUNTIME_DIR/provider.mode" 2>/dev/null)
                 if [ -n "$provider" ]; then
-                    local provider_display="${provider^^}"
+                    local provider_display
+                    provider_display=$(printf '%s' "$provider" | tr '[:lower:]' '[:upper:]')
                     echo -e "  ${GREEN}🌐 Mode:${NC} $provider_display"
                 fi
             fi


### PR DESCRIPTION
## Goal
Ensure the proxy status command works on macOS systems that still ship with Bash 3.2.

## Modifications
- Replace the Bash 4 `${var^^}` uppercase expansion with a portable `tr` pipeline when rendering the provider mode.

## Necessity
Without this change, running `./proxy.sh status` on the default macOS shell triggers a `bad substitution` error and hides the provider mode information.

## Integration Proof
- `./proxy.sh status`


------
https://chatgpt.com/codex/tasks/task_e_68d8691525a0832fa08b91502a4e1728

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Bash 4 `${var^^}` with a `tr` pipeline to uppercase `provider.mode` for status output, ensuring compatibility with older Bash (e.g., macOS 3.2).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d7e2d2d171732ca5687ed8ee41a5b535a31995a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->