### PR TITLE
chore(reviewdeep): document command and stabilize cerebras startup

### DIFF
--- a/.codexplus/commands/reviewdeep.md
+++ b/.codexplus/commands/reviewdeep.md
@@ -1,0 +1,44 @@
+# /reviewdeep Command
+
+**Purpose**
+Deliver a high-signal, security-aware code review entirely inside the CLI harness—no MCP agents or external automation required. Mirrors the manual process we just ran.
+
+## Usage
+```bash
+/reviewdeep [<path>|<PR>]      # review current checkout or specific target
+```
+
+## Review Flow
+1. **Context & Diff Intake**
+   - `git status -sb` for scope
+   - `git show HEAD` (or staged diff) for patch view
+
+2. **Analysis Tracks**
+   - **Correctness & Design**: inspect key files, invariants, regression risk
+   - **Security & Error Surfaces**: auth flows, trust boundaries, error propagation
+   - **Testing & Coverage**: confirm existing or missing automated tests
+
+3. **CLI Helpers (optional)**
+   - `rg`, local scripts for targeted search
+   - Project test suite (`npm run test`, etc.) if quick enough
+
+4. **Synthesis**
+   - Summarize findings ordered by severity (High/Med/Low/Info)
+   - Each finding = title, file:line when possible, impact, remediation guidance
+   - Record verification steps (tests run, manual checks)
+
+## Output Template
+```
+Findings
+- High – <title> (<file:line>): <issue + fix>
+- Medium – ...
+
+Verification
+- Tests: <commands> (pass/fail)
+- Notes: <manual review, scripts run>
+```
+
+## Notes
+- Built for solo maintainers; emphasize actionable steps over exhaustive prose
+- No MCP requirements; runs fully in sandboxed CLI
+- Keep responses concise and evidence-backed

--- a/.codexplus/commands/reviewdeep.md
+++ b/.codexplus/commands/reviewdeep.md
@@ -31,7 +31,7 @@ Deliver a high-signal, security-aware code review entirely inside the CLI harnes
 ```
 Findings
 - High - <title> (<file:line>): <issue + fix>
-- Medium – ...
+- Medium - ...
 
 Verification
 - Tests: <commands> (pass/fail)

--- a/.codexplus/commands/reviewdeep.md
+++ b/.codexplus/commands/reviewdeep.md
@@ -1,7 +1,7 @@
 # /reviewdeep Command
 
 **Purpose**
-Deliver a high-signal, security-aware code review entirely inside the CLI harness—no MCP agents or external automation required. Mirrors the manual process we just ran.
+Deliver a high-signal, security-aware code review entirely inside the CLI harness - no MCP agents or external automation required. Mirrors the manual process we just ran.
 
 ## Usage
 ```bash
@@ -30,7 +30,7 @@ Deliver a high-signal, security-aware code review entirely inside the CLI harnes
 ## Output Template
 ```
 Findings
-- High – <title> (<file:line>): <issue + fix>
+- High - <title> (<file:line>): <issue + fix>
 - Medium – ...
 
 Verification

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ main() {
   rc_file="$(choose_shell_rc)"
   echo "Using shell configuration: $rc_file"
   append_snippet "$rc_file"
-  echo "\nNext steps:"
+  printf '\nNext steps:\n'
   echo "  1. source \"$rc_file\" (or restart your shell)."
   echo "  2. Run \"codex-plus-proxy enable\" to start the proxy (aliases to proxy.sh)."
   echo "  3. Use \"codex\" or \"codexd\" to automatically route through Codex-Plus when the proxy is running."


### PR DESCRIPTION
## Goal
Document the /reviewdeep workflow while keeping the Cerebras proxy startup flow and installer guidance aligned with main, and ensure command discovery respects user-level overrides.

## Modifications
- docs: add `.codexplus/commands/reviewdeep.md` outlining usage, review flow, and output expectations
- proxy.sh: auto-source Cerebras env vars, force restarts when relaunching in Cerebras mode, and refresh help text
- install.sh: use portable `printf` for the "Next steps" banner
- middleware: allow `.codexplus/commands` overrides from both the repo and `~/.codexplus/`
- tests: extend command-resolution coverage for home-directory and precedence behavior

## Necessity
Gives maintainers an authoritative /reviewdeep reference, keeps Cerebras proxy startup reliable, ensures installation output renders consistently, and lets personalized command definitions coexist alongside project defaults.

## Integration Proof
- Manual: `./proxy.sh status` (running in Cerebras mode)
- Tests: `pytest tests/test_enhanced_slash_middleware_claude_dir.py`

---

**Commits vs origin/main**
8016820 fix(commands): load home codexplus command overrides
2abb903 fix(install): print next steps newline portably
770df45 fix(proxy): force cerebras restart
82f240a docs(commands): normalize dash usage in reviewdeep guide
19f2e5e docs(commands): add reviewdeep command guide
