### PR TITLE
fix: detach proxy from terminal closure

### DIFF
--- a/proxy.sh
+++ b/proxy.sh
@@ -320,7 +320,8 @@ start_proxy() {
     # 🚨🚨🚨 CRITICAL PROXY STARTUP COMMAND - DO NOT MODIFY 🚨🚨🚨
     # ⚠️ This command starts the curl_cffi proxy with Cloudflare bypass ⚠️
     # ❌ FORBIDDEN: Changing module, host, port, or import structure
-    nohup python -c "
+    # Use setsid to fully detach the proxy so it survives terminal closure
+    nohup setsid python -c "
 import sys, os
 try:
     from codex_plus.$PROXY_MODULE import app


### PR DESCRIPTION
## Goal
- Ensure the Codex proxy keeps running even after the launching terminal session ends.

## Modifications
- Wrap the protected Python startup command in `setsid` so the uvicorn process is fully detached from the controlling terminal.
- Document the detach behavior directly above the command for future maintainers.

## Necessity
- Previously the proxy could terminate when the originating terminal closed, interrupting Codex traffic; detaching the process prevents that disruption.

## Integration Proof
- Not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68db7ab54e44832fa83685e8b05e44c7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap the protected Python startup in `nohup setsid` so the uvicorn proxy keeps running after the terminal closes.
> 
> - **Script `proxy.sh`**:
>   - **Startup**: Replace `nohup python -c` with `nohup setsid python -c` to fully detach the uvicorn proxy on `127.0.0.1:10000`.
>   - **Docs**: Add inline comment explaining the detach behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9c78ed43f9d304460412f06a9969a16e29c3924. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->