### PR TITLE
fix(hooks): preserve nested pre-input mutations

### DIFF
--- a/src/codex_plus/main_sync_cffi.py
+++ b/src/codex_plus/main_sync_cffi.py
@@ -187,14 +187,20 @@ async def proxy(request: Request, path: str):
     if body and path == "responses":
         try:
             body_dict = _json.loads(body)
-            original_body_snapshot = copy.deepcopy(body_dict)
             modified = await process_pre_input_hooks(request, body_dict)
 
             # Hooks may mutate the provided body in place or return a new object
             if modified is None:
                 modified = body_dict
 
-            if modified != original_body_snapshot:
+            body_changed = False
+            if modified is body_dict:
+                original_body_snapshot = _json.loads(body)
+                body_changed = modified != original_body_snapshot
+            else:
+                body_changed = True
+
+            if body_changed:
                 # stash modified body for downstream middleware
                 try:
                     request.state.modified_body = _json.dumps(modified).encode('utf-8')

--- a/src/codex_plus/main_sync_cffi.py
+++ b/src/codex_plus/main_sync_cffi.py
@@ -35,7 +35,6 @@ from fastapi.responses import StreamingResponse, JSONResponse
 from curl_cffi import requests
 import logging
 import json as _json
-import json
 import sys
 import os
 import time

--- a/src/codex_plus/main_sync_cffi.py
+++ b/src/codex_plus/main_sync_cffi.py
@@ -40,7 +40,6 @@ import sys
 import os
 import time
 import re
-import copy
 from urllib.parse import urlparse
 from .status_line_middleware import HookMiddleware
 

--- a/tests/test_hooks_integration.py
+++ b/tests/test_hooks_integration.py
@@ -160,6 +160,7 @@ hook = MutateNested('mutate-nested', {'type': 'pre-input', 'priority': 5, 'enabl
             }
             r = client.post("/responses", json=payload)
             assert r.status_code == 200
+            # Positional args are unused; the request payload lives in kwargs.
             _args, kwargs = mock_session.request.call_args
             sent_body = kwargs.get("data")
             assert isinstance(sent_body, (bytes, bytearray))

--- a/tests/test_hooks_integration.py
+++ b/tests/test_hooks_integration.py
@@ -16,7 +16,7 @@ def write_hook(dir_path: Path, name: str, body: str) -> Path:
     return p
 
 
-def test_pre_input_hook_modifies_upstream_body(tmp_path):
+def test_pre_input_hook_modifies_upstream_body():
     # Arrange: create a pre-input hook that injects a marker into the body
     hooks_dir = Path(".codexplus/hooks")
     hook_code = """---
@@ -82,7 +82,7 @@ hook = InjectMarker('inject-marker', {'type':'pre-input','priority':10,'enabled'
             pass
 
 
-def test_pre_input_hook_nested_mutation_propagates(tmp_path):
+def test_pre_input_hook_nested_mutation_propagates():
     from codex_plus import main_sync_cffi
 
     # Ensure the middleware creates a fresh session so our patch applies

--- a/tests/test_hooks_integration.py
+++ b/tests/test_hooks_integration.py
@@ -80,3 +80,90 @@ hook = InjectMarker('inject-marker', {'type':'pre-input','priority':10,'enabled'
                     parent.rmdir()
         except Exception:
             pass
+
+
+def test_pre_input_hook_nested_mutation_propagates(tmp_path):
+    from codex_plus import main_sync_cffi
+
+    # Ensure the middleware creates a fresh session so our patch applies
+    if hasattr(main_sync_cffi.slash_middleware, "_session"):
+        delattr(main_sync_cffi.slash_middleware, "_session")
+
+    hooks_dir = Path(".codexplus/hooks")
+    hook_code = """---
+name: mutate-nested
+type: pre-input
+priority: 5
+enabled: true
+---
+from codex_plus.hooks import Hook
+
+class MutateNested(Hook):
+    name = "mutate-nested"
+    async def pre_input(self, request, body):
+        messages = body.get('input') or []
+        if messages and isinstance(messages, list):
+            first = messages[0]
+            if isinstance(first, dict):
+                content = first.get('content')
+                if isinstance(content, list) and content:
+                    block = content[0]
+                    if isinstance(block, dict) and block.get('type') == 'input_text':
+                        block['text'] = f"[HOOKED] {block.get('text', '')}"
+        return body
+hook = MutateNested('mutate-nested', {'type': 'pre-input', 'priority': 5, 'enabled': True})
+"""
+    hook_file = write_hook(hooks_dir, "mutate_nested", hook_code)
+
+    try:
+        try:
+            hooks_mod.hook_system._load_hooks()
+        except RuntimeError as e:
+            if "Event loop is closed" in str(e):
+                hooks_mod.hook_system = hooks_mod.HookSystem()
+            else:
+                raise
+
+        client = TestClient(app)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.iter_content.return_value = iter([b"{}"])
+
+        with patch("curl_cffi.requests.Session") as mock_session_cls:
+            mock_session = Mock()
+            mock_session.request.return_value = mock_response
+            mock_session_cls.return_value = mock_session
+
+            payload = {
+                "model": "gpt-5",
+                "instructions": "Test",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "/echo hi"}
+                        ],
+                    }
+                ],
+            }
+            r = client.post("/responses", json=payload)
+            assert r.status_code == 200
+            args, kwargs = mock_session.request.call_args
+            sent_body = kwargs.get("data")
+            assert isinstance(sent_body, (bytes, bytearray))
+            sent_json = json.loads(sent_body)
+            nested_text = sent_json["input"][0]["content"][0]["text"]
+            assert "[HOOKED]" in nested_text
+    finally:
+        try:
+            hook_file.unlink(missing_ok=True)
+            if hooks_dir.exists() and not any(hooks_dir.iterdir()):
+                hooks_dir.rmdir()
+                parent = hooks_dir.parent
+                if parent.exists() and not any(parent.iterdir()):
+                    parent.rmdir()
+        except Exception:
+            pass


### PR DESCRIPTION
## Goal
Ensure pre-input hooks that mutate nested request structures have their changes forwarded to the upstream service.

## Modifications
- Capture a deep copy of the original /responses payload and use it to detect in-place hook mutations before handing off to the middleware.
- Added a regression test that exercises a nested pre-input mutation to confirm the modified payload is sent upstream.

## Necessity
Previously, hooks that edited nested dictionaries or lists did so in place, leaving the original payload unchanged and skipping the forwarding of those edits. This caused unexpected loss of hook-driven request mutations.

## Integration Proof
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68de50b7d684832fbf4e3323930273b3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects and forwards in-place/nested pre-input hook mutations for /responses requests; adds a regression test verifying nested mutation propagation.
> 
> - **Hooks/Proxy (`src/codex_plus/main_sync_cffi.py`)**:
>   - Improve detection of pre-input modifications for `POST /responses` by handling:
>     - Hooks returning `None` (treat as in-place mutation of original body).
>     - In-place mutations on the same object via snapshot comparison of original JSON.
>   - When changes are detected, stash `request.state.modified_body` for downstream middleware.
> - **Tests (`tests/test_hooks_integration.py`)**:
>   - Add regression test `test_pre_input_hook_nested_mutation_propagates` validating nested in-place mutations are sent upstream.
>   - Minor tweak to existing test setup to streamline hook loading and client/session initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c19524eb4e7be9c75797a4a5bea597fb324b02d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Ensures pre-input hooks reliably apply and propagate both in-place and returned nested mutations to upstream requests.
  - Improves detection of modified request bodies and logs when hooks alter payloads.
  - Preserves existing behavior for blocked prompts and JSON decoding errors.

- Tests
  - Added an end-to-end test validating nested pre-input hook mutations are reflected in upstream payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->