### PR TITLE
chore: capture Cerebras tool output follow-ups

### DIFF
--- a/roadmap/cerebras_openai_passthrough_design.md
+++ b/roadmap/cerebras_openai_passthrough_design.md
@@ -1,0 +1,22 @@
+# Cerebras Passthrough Debugging Notes
+
+## Tool Output Capture
+
+- Added `/tmp/codex_plus/cereb_conversion/tool_outputs_*.json` snapshots that
+  capture the Codex CLI follow-up request after a tool call.  The logger removes
+  `Authorization`/`Cookie` headers and writes the sanitized payload using
+  `asyncio.to_thread` so the proxy hot-path stays non-blocking.
+- These records allow us to confirm whether the CLI submits tool output payloads
+  and inspect their format while we continue aligning the Cerebras handler with
+  OpenAI's `/responses` contract.
+- Each snapshot includes the request path and raw JSON body to make it easy to
+  diff against the ChatGPT baseline responses captured under
+  `/tmp/codex_plus/chatgpt_responses/`.
+
+## Next Steps
+
+- Wire the captured payloads into the Cerebras translator so `/responses/{id}/tool_outputs`
+  can be replayed against `chat/completions` without manual intervention.
+- Once the upstream call succeeds, emit the matching
+  `response.function_call_arguments.*` and `response.output_item.*` events so the
+  Codex CLI resumes execution automatically.

--- a/src/codex_plus/cerebras_tool_output_logger.py
+++ b/src/codex_plus/cerebras_tool_output_logger.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, MutableMapping, Optional
@@ -117,13 +118,14 @@ async def record_tool_outputs(
 
     await ensure_log_dir()
 
-    log_file = LOG_DIR / f"tool_outputs_{os.getpid()}_{asyncio.get_running_loop().time():.0f}.json"
+    timestamp_ns = time.time_ns()
+    log_file = LOG_DIR / f"tool_outputs_{os.getpid()}_{timestamp_ns}.json"
     await _write_json(log_file, {
         "path": record.path,
         "body": record.body,
         "headers": record.headers,
     })
 
-    logger.info("🪵 Recorded Cerebras tool output follow-up to %s", log_file)
+    logger.info("[TOOL_OUTPUT] Recorded Cerebras tool output follow-up to %s", log_file)
     return log_file
 

--- a/src/codex_plus/cerebras_tool_output_logger.py
+++ b/src/codex_plus/cerebras_tool_output_logger.py
@@ -1,0 +1,129 @@
+"""Utility helpers for inspecting Cerebras tool output follow-up requests.
+
+These helpers are intentionally lightweight so they can run inside the proxy's
+request path without introducing blocking network calls.  The logger mirrors
+the structure we already use for capturing prompt payloads under
+``/tmp/codex_plus/<branch>/`` but stores information in the
+``/tmp/codex_plus/cereb_conversion`` directory that the oncall team monitors
+when validating the Cerebras integration.
+
+The helpers are designed to be safe to call from async contexts – all file
+operations happen in a background executor via ``asyncio.to_thread`` – and the
+payload is lightly redacted to avoid leaking bearer tokens.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, MutableMapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+LOG_DIR = Path("/tmp/codex_plus/cereb_conversion")
+"""Location used for the Cerebras conversion debugging logs."""
+
+
+@dataclass(slots=True)
+class ToolOutputRecord:
+    """Represents a structured log entry for a tool output submission."""
+
+    path: str
+    body: Mapping[str, object]
+    headers: Mapping[str, str]
+
+    def redact(self) -> "ToolOutputRecord":
+        """Return a copy of the record with sensitive headers removed.
+
+        The Codex CLI includes the same authentication cookie that the ChatGPT
+        backend expects.  We do not want that value to end up on disk.  When we
+        need to debug authentication issues we can rely on the proxy's main
+        request logs instead.
+        """
+
+        safe_headers: MutableMapping[str, str] = {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in {"cookie", "authorization"}
+        }
+
+        return ToolOutputRecord(path=self.path, body=self.body, headers=safe_headers)
+
+
+async def ensure_log_dir() -> None:
+    """Make sure the Cerebras debugging directory exists."""
+
+    if LOG_DIR.exists():
+        return
+
+    def _mkdir() -> None:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    await asyncio.to_thread(_mkdir)
+
+
+async def _write_json(path: Path, data: Mapping[str, object]) -> None:
+    """Write *data* to ``path`` using ``asyncio.to_thread``."""
+
+    def _dump() -> None:
+        with path.open("w", encoding="utf-8") as fp:
+            json.dump(data, fp, indent=2, ensure_ascii=False)
+
+    await asyncio.to_thread(_dump)
+
+
+async def record_tool_outputs(
+    *,
+    path: str,
+    body_bytes: Optional[bytes],
+    headers: Mapping[str, str],
+) -> Optional[Path]:
+    """Persist a snapshot of a tool output follow-up request.
+
+    Parameters
+    ----------
+    path:
+        The request path, e.g. ``"responses/resp_123/tool_outputs"``.
+    body_bytes:
+        Raw request body, assumed to be JSON encoded.  ``None`` or invalid JSON
+        payloads are ignored to avoid raising in the proxy hot-path.
+    headers:
+        The request headers used to redact authentication fields in the stored
+        snapshot.
+
+    Returns
+    -------
+    Path or ``None``
+        The file path where the log entry was written.  ``None`` indicates we
+        skipped logging because the payload could not be decoded.
+    """
+
+    if not body_bytes:
+        logger.debug("Cerebras tool output record skipped: empty body")
+        return None
+
+    try:
+        parsed = json.loads(body_bytes)
+    except json.JSONDecodeError:
+        logger.warning("Cerebras tool output record skipped: body not JSON")
+        return None
+
+    record = ToolOutputRecord(path=path, body=parsed, headers=dict(headers)).redact()
+
+    await ensure_log_dir()
+
+    log_file = LOG_DIR / f"tool_outputs_{os.getpid()}_{asyncio.get_running_loop().time():.0f}.json"
+    await _write_json(log_file, {
+        "path": record.path,
+        "body": record.body,
+        "headers": record.headers,
+    })
+
+    logger.info("🪵 Recorded Cerebras tool output follow-up to %s", log_file)
+    return log_file
+

--- a/tests/test_cerebras_tool_logging.py
+++ b/tests/test_cerebras_tool_logging.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plus import cerebras_tool_output_logger as tool_logger
+
+
+@pytest.mark.asyncio
+async def test_record_tool_outputs_writes_redacted_snapshot(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(tool_logger, "LOG_DIR", tmp_path)
+
+    payload = {"tool_outputs": [{"tool_call_id": "call_1", "output": "ok"}]}
+
+    result_path = await tool_logger.record_tool_outputs(
+        path="responses/resp_123/tool_outputs",
+        body_bytes=json.dumps(payload).encode("utf-8"),
+        headers={"Authorization": "topsecret", "X-Test": "value"},
+    )
+
+    assert result_path is not None
+    assert result_path.exists()
+
+    recorded = json.loads(result_path.read_text("utf-8"))
+    assert recorded["path"] == "responses/resp_123/tool_outputs"
+    assert recorded["body"] == payload
+    assert "Authorization" not in recorded["headers"]
+    assert recorded["headers"]["X-Test"] == "value"
+
+
+@pytest.mark.asyncio
+async def test_record_tool_outputs_ignores_invalid_json(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(tool_logger, "LOG_DIR", tmp_path)
+
+    result_path = await tool_logger.record_tool_outputs(
+        path="responses/resp_123/tool_outputs",
+        body_bytes=b"not-json",
+        headers={},
+    )
+
+    assert result_path is None
+    assert not any(tmp_path.iterdir())
+


### PR DESCRIPTION
## Goal
- Capture the Codex CLI tool-output payloads that follow Cerebras tool calls so we can debug the hand-off to `chat/completions`.

## Modifications
- Added an async-safe logger that stores sanitized `/responses/{id}/tool_outputs` bodies under `/tmp/codex_plus/cereb_conversion/`.
- Hooked the middleware so Cerebras mode records every follow-up payload without disrupting the main proxy path.
- Documented the new snapshots and next steps in `roadmap/cerebras_openai_passthrough_design.md`.
- Introduced unit tests covering the logger and JSON handling edge cases.

## Necessity
- Without visibility into the follow-up requests we cannot finish the Cerebras translation required for end-to-end tool execution.

## Integration Proof
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e41f34a970832f8467fa7a0329559d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an async-safe logger to snapshot sanitized Cerebras `/responses/{id}/tool_outputs` payloads, integrates it into the proxy middleware, and adds tests and docs.
> 
> - **Proxy/Backend**:
>   - **Cerebras tool output logging**: New `src/codex_plus/cerebras_tool_output_logger.py` with `record_tool_outputs` that redacts `Authorization`/`Cookie` and writes snapshots to `/tmp/codex_plus/cereb_conversion/`.
>   - **Middleware integration**: `LLMExecutionMiddleware.process_request` conditionally records `responses/.../tool_outputs` payloads in Cerebras mode without blocking the hot path.
> - **Tests**: `tests/test_cerebras_tool_logging.py` covers redaction behavior and invalid JSON handling.
> - **Docs**: Adds debugging notes and next steps in `roadmap/cerebras_openai_passthrough_design.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b88fb06144cc38ace0ace5f29a55304267306196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->