### PR TITLE
fix(proxy): guard port before starting proxy

### DIFF
--- a/src/codex_plus/port_guard.py
+++ b/src/codex_plus/port_guard.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_EXPECTED_MARKERS: Sequence[str] = (
+    "codex_plus",
+    "main_sync_cffi",
+    "uvicorn",
+)
+_LSOF_COMMAND: Sequence[str] = ("lsof", "-nP")
+
+
+class PortGuardError(RuntimeError):
+    """Raised when inspecting the system state fails."""
+
+
+class PortState(str, Enum):
+    FREE = "free"
+    OWNED_BY_PROXY = "owned_by_proxy"
+    OCCUPIED_OTHER = "occupied_other"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ProcessInfo:
+    pid: int
+    command: str
+
+
+@dataclass(frozen=True)
+class PortCheckResult:
+    state: PortState
+    processes: tuple[ProcessInfo, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "state": self.state.value,
+            "processes": [
+                {"pid": p.pid, "command": p.command}
+                for p in self.processes
+            ],
+        }
+
+
+def _run_lsof(port: int) -> list[ProcessInfo]:
+    command = list(_LSOF_COMMAND) + [f"-iTCP:{port}", "-sTCP:LISTEN", "-Fpc"]
+    try:
+        proc = subprocess.run(  # noqa: S603 - controlled command, arguments list
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - depends on environment
+        raise PortGuardError("lsof command not available") from exc
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover - defensive
+        raise PortGuardError("lsof command timed out") from exc
+
+    stdout = proc.stdout or ""
+    if not stdout.strip():
+        return []
+
+    processes: list[ProcessInfo] = []
+    current_pid: int | None = None
+    current_command: str | None = None
+
+    for raw_line in stdout.splitlines():
+        if not raw_line:
+            continue
+        tag, value = raw_line[0], raw_line[1:]
+        if tag == "p":
+            if current_pid is not None and current_command is not None:
+                processes.append(ProcessInfo(pid=current_pid, command=current_command))
+            try:
+                current_pid = int(value)
+            except ValueError:
+                current_pid = None
+            current_command = None
+        elif tag == "c":
+            current_command = value
+
+    if current_pid is not None and current_command is not None:
+        processes.append(ProcessInfo(pid=current_pid, command=current_command))
+
+    return processes
+
+
+def _probe_health(url: str, timeout: float = 1.0) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310 - intentional
+            if response.status >= 200 and response.status < 300:
+                return True
+    except (urllib.error.URLError, ValueError, TimeoutError):
+        return False
+    return False
+
+
+def _matches_expected(process: ProcessInfo, expected_markers: Iterable[str]) -> bool:
+    haystack = process.command.lower()
+    return any(marker.lower() in haystack for marker in expected_markers)
+
+
+def check_port_ownership(
+    port: int,
+    *,
+    expected_markers: Sequence[str] | None = None,
+    health_url: str | None = None,
+    health_timeout: float = 1.0,
+) -> PortCheckResult:
+    markers = expected_markers or _DEFAULT_EXPECTED_MARKERS
+    try:
+        processes = tuple(_run_lsof(port))
+    except PortGuardError as exc:
+        logger.debug("port guard failed", exc_info=exc)
+        return PortCheckResult(state=PortState.UNKNOWN, processes=())
+
+    if not processes:
+        return PortCheckResult(state=PortState.FREE, processes=())
+
+    for process in processes:
+        if _matches_expected(process, markers):
+            return PortCheckResult(state=PortState.OWNED_BY_PROXY, processes=processes)
+
+    if health_url and _probe_health(health_url, timeout=health_timeout):
+        return PortCheckResult(state=PortState.OWNED_BY_PROXY, processes=processes)
+
+    return PortCheckResult(state=PortState.OCCUPIED_OTHER, processes=processes)
+
+
+_EXIT_CODE_BY_STATE = {
+    PortState.OWNED_BY_PROXY: 0,
+    PortState.FREE: 10,
+    PortState.OCCUPIED_OTHER: 20,
+    PortState.UNKNOWN: 30,
+}
+
+
+def _cli() -> int:
+    parser = argparse.ArgumentParser(description="Inspect ownership of the Codex proxy port")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--expect", action="append", dest="expected", default=[])
+    parser.add_argument("--health-url", dest="health_url")
+    parser.add_argument("--health-timeout", type=float, default=1.0)
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+    args = parser.parse_args()
+
+    expected = tuple(args.expected) if args.expected else None
+    result = check_port_ownership(
+        port=args.port,
+        expected_markers=expected,
+        health_url=args.health_url,
+        health_timeout=args.health_timeout,
+    )
+
+    if args.json:
+        print(json.dumps(result.to_dict()))
+    else:
+        summary = result.to_dict()
+        printable = json.dumps(summary, indent=2)
+        print(printable)
+
+    return _EXIT_CODE_BY_STATE[result.state]
+
+
+def main() -> None:  # pragma: no cover - simple wrapper
+    sys.exit(_cli())
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_port_guard.py
+++ b/tests/test_port_guard.py
@@ -1,19 +1,9 @@
 from __future__ import annotations
 
-import types
-from typing import List
-
 import pytest
 
 from codex_plus import port_guard
 from codex_plus.port_guard import PortState, PortCheckResult
-
-
-class DummyCompletedProcess:
-    def __init__(self, stdout: str, returncode: int = 0, stderr: str = "") -> None:
-        self.stdout = stdout
-        self.returncode = returncode
-        self.stderr = stderr
 
 
 @pytest.fixture()
@@ -23,10 +13,7 @@ def reset_module_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_check_port_ownership_free_port(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_run(*args, **kwargs):  # noqa: ANN001
-        return DummyCompletedProcess(stdout="")
-
-    monkeypatch.setattr(port_guard, "_run_lsof", lambda port: [])
+    monkeypatch.setattr(port_guard, "_run_lsof", lambda _port: [])
     result = port_guard.check_port_ownership(port=10000, expected_markers=("codex_plus",))
     assert result == PortCheckResult(state=PortState.FREE, processes=())
 
@@ -35,17 +22,18 @@ def test_check_port_ownership_owned_by_proxy_via_command(monkeypatch: pytest.Mon
     processes = [
         port_guard.ProcessInfo(pid=1234, command="python -c from codex_plus.main_sync_cffi import app"),
     ]
-    monkeypatch.setattr(port_guard, "_run_lsof", lambda port: processes)
+    monkeypatch.setattr(port_guard, "_run_lsof", lambda _port: processes)
     result = port_guard.check_port_ownership(port=10000, expected_markers=("codex_plus",))
     assert result.state is PortState.OWNED_BY_PROXY
     assert result.processes == tuple(processes)
 
 
 def test_check_port_ownership_owned_by_proxy_via_health(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(port_guard, "_run_lsof", lambda port: [port_guard.ProcessInfo(pid=4321, command="python other")])
+    monkeypatch.setattr(port_guard, "_run_lsof", lambda _port: [port_guard.ProcessInfo(pid=4321, command="python other")])
 
-    def fake_health(url: str, timeout: float) -> bool:  # noqa: ANN001
+    def fake_health(url: str, timeout: float) -> bool:
         assert url == "http://127.0.0.1:10000/health"
+        assert timeout == 1.0
         return True
 
     monkeypatch.setattr(port_guard, "_probe_health", fake_health)
@@ -58,16 +46,18 @@ def test_check_port_ownership_owned_by_proxy_via_health(monkeypatch: pytest.Monk
 
 
 def test_check_port_ownership_occupied(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(port_guard, "_run_lsof", lambda port: [port_guard.ProcessInfo(pid=77, command="redis-server")])
-    monkeypatch.setattr(port_guard, "_probe_health", lambda url, timeout: False)
+    monkeypatch.setattr(port_guard, "_run_lsof", lambda _port: [port_guard.ProcessInfo(pid=77, command="redis-server")])
+    monkeypatch.setattr(port_guard, "_probe_health", lambda _url, _timeout: False)
     result = port_guard.check_port_ownership(port=10000, expected_markers=("codex_plus",))
     assert result.state is PortState.OCCUPIED_OTHER
     assert result.processes[0].pid == 77
 
 
 def test_check_port_ownership_unknown_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    def raising_lsof(port: int) -> List[port_guard.ProcessInfo]:  # noqa: ANN001
-        raise port_guard.PortGuardError("lsof missing")
+    error = port_guard.PortGuardError("lsof missing")
+
+    def raising_lsof(_port: int) -> tuple[port_guard.ProcessInfo, ...]:
+        raise error
 
     monkeypatch.setattr(port_guard, "_run_lsof", raising_lsof)
     result = port_guard.check_port_ownership(port=10000, expected_markers=("codex_plus",))

--- a/tests/test_port_guard.py
+++ b/tests/test_port_guard.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import types
+from typing import List
+
+import pytest
+
+from codex_plus import port_guard
+from codex_plus.port_guard import PortState, PortCheckResult
+
+
+class DummyCompletedProcess:
+    def __init__(self, stdout: str, returncode: int = 0, stderr: str = "") -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+@pytest.fixture()
+def reset_module_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(port_guard, "_LSOF_COMMAND", ["lsof"])
+    monkeypatch.setattr(port_guard, "_DEFAULT_EXPECTED_MARKERS", tuple(port_guard._DEFAULT_EXPECTED_MARKERS))
+
+
+def test_check_port_ownership_free_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*args, **kwargs):  # noqa: ANN001
+        return DummyCompletedProcess(stdout="")
+
+    monkeypatch.setattr(port_guard, "_run_lsof", lambda port: [])
+    result = port_guard.check_port_ownership(port=10000, expected_markers=("codex_plus",))
+    assert result == PortCheckResult(state=PortState.FREE, processes=())
+
+
+def test_check_port_ownership_owned_by_proxy_via_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    processes = [
+        port_guard.ProcessInfo(pid=1234, command="python -c from codex_plus.main_sync_cffi import app"),
+    ]
+    monkeypatch.setattr(port_guard, "_run_lsof", lambda port: processes)
+    result = port_guard.check_port_ownership(port=10000, expected_markers=("codex_plus",))
+    assert result.state is PortState.OWNED_BY_PROXY
+    assert result.processes == tuple(processes)
+
+
+def test_check_port_ownership_owned_by_proxy_via_health(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(port_guard, "_run_lsof", lambda port: [port_guard.ProcessInfo(pid=4321, command="python other")])
+
+    def fake_health(url: str, timeout: float) -> bool:  # noqa: ANN001
+        assert url == "http://127.0.0.1:10000/health"
+        return True
+
+    monkeypatch.setattr(port_guard, "_probe_health", fake_health)
+    result = port_guard.check_port_ownership(
+        port=10000,
+        expected_markers=("codex_plus",),
+        health_url="http://127.0.0.1:10000/health",
+    )
+    assert result.state is PortState.OWNED_BY_PROXY
+
+
+def test_check_port_ownership_occupied(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(port_guard, "_run_lsof", lambda port: [port_guard.ProcessInfo(pid=77, command="redis-server")])
+    monkeypatch.setattr(port_guard, "_probe_health", lambda url, timeout: False)
+    result = port_guard.check_port_ownership(port=10000, expected_markers=("codex_plus",))
+    assert result.state is PortState.OCCUPIED_OTHER
+    assert result.processes[0].pid == 77
+
+
+def test_check_port_ownership_unknown_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raising_lsof(port: int) -> List[port_guard.ProcessInfo]:  # noqa: ANN001
+        raise port_guard.PortGuardError("lsof missing")
+
+    monkeypatch.setattr(port_guard, "_run_lsof", raising_lsof)
+    result = port_guard.check_port_ownership(port=10000, expected_markers=("codex_plus",))
+    assert result.state is PortState.UNKNOWN

--- a/tests/test_proxy_script_guard.py
+++ b/tests/test_proxy_script_guard.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "proxy.sh"
+
+
+@pytest.mark.skipif(not SCRIPT_PATH.exists(), reason="proxy script missing")
+def test_proxy_enable_exits_when_guard_reports_owned(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / "runtime"
+    env = os.environ.copy()
+    env.update(
+        {
+            "CODEX_PROXY_GUARD_STATE": "owned_by_proxy",
+            "CODEX_PROXY_RUNTIME_DIR": str(runtime_dir),
+        }
+    )
+
+    result = subprocess.run(  # noqa: S603
+        ["bash", str(SCRIPT_PATH), "enable"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "Proxy already running" in result.stdout
+    assert not (runtime_dir / "proxy.pid").exists()


### PR DESCRIPTION
Goal:\n- stop launchd proxy restarts when port 10000 is already serving the Codex proxy.\n\nModifications:\n- add a python-based port guard that inspects lsof output and /health before start.\n- teach proxy.sh to consult the guard, respect CODEX_PROXY_RUNTIME_DIR, and refuse to kill unrelated listeners.\n- cover the new behaviours with focused pytest suites for the guard and shell script.\n\nNecessity:\n- without the guard the LaunchAgent thrashes when stale listeners exist, flooding logs and returning 429s/503s.\n\nIntegration Proof:\n- pytest -q\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates a Python-based port guard, updates proxy startup to respect port ownership and runtime dir overrides, and adds tests.
> 
> - **Proxy script (`proxy.sh`)**:
>   - Integrates `codex_plus.port_guard` to check port `10000` ownership before start:
>     - Skips startup if `owned_by_proxy` (exit 0); refuses if `occupied_other` (exit 20); proceeds if `unknown`.
>   - Supports `CODEX_PROXY_RUNTIME_DIR` for runtime files (`proxy.pid`, `proxy.log`, `proxy.lock`, `provider.base_url`).
>   - Removes aggressive orphaned-process cleanup from `cleanup_stale_resources`.
> - **New module (`src/codex_plus/port_guard.py`)**:
>   - Determines port ownership via `lsof` and optional `/health` probe; provides CLI (`python -m codex_plus.port_guard`) with JSON output and exit codes (0/10/20/30).
> - **Tests**:
>   - Add `tests/test_port_guard.py` covering free/owned/occupied/unknown states.
>   - Add `tests/test_proxy_script_guard.py` verifying proxy exits early when guard reports `owned_by_proxy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5919378b50e5513e05b295527ef299d40b00379e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support overriding the proxy runtime directory via an environment variable.
  - Introduced a port guard that detects port ownership, preventing conflicts and providing clear status messages.
- Refactor
  - Startup flow now consults the port guard: skips if already running, aborts with explanation if the port is in use by another process, or proceeds when uncertain.
  - Enhanced startup messaging with health-check verification and upstream/logging status.
  - Integrated locking with port-guard decisions for more reliable startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->