### PR TITLE
test(proxy): add launchd coverage

### DIFF
--- a/scripts/proxy_launchd.sh
+++ b/scripts/proxy_launchd.sh
@@ -4,6 +4,28 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENV_PATH="$SCRIPT_DIR/venv"
+RUNTIME_DIR="${CODEX_PROXY_RUNTIME_DIR:-/tmp/codex_plus}"
+PID_FILE="$RUNTIME_DIR/proxy.pid"
+LOG_FILE="$RUNTIME_DIR/proxy.log"
+ERROR_LOG_FILE="$RUNTIME_DIR/proxy.err"
+LAUNCHD_ENV_FILE="$RUNTIME_DIR/launchd.env"
+
+mkdir -p "$RUNTIME_DIR"
+if [ ! -f "$LOG_FILE" ]; then
+  touch "$LOG_FILE"
+fi
+if [ ! -f "$ERROR_LOG_FILE" ]; then
+  touch "$ERROR_LOG_FILE"
+fi
+chmod 644 "$LOG_FILE" "$ERROR_LOG_FILE" 2>/dev/null || true
+
+unset CODEX_PLUS_LOGGING_MODE
+if [ -f "$LAUNCHD_ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$LAUNCHD_ENV_FILE"
+  set +a
+fi
 
 if [ ! -d "$VENV_PATH" ]; then
   echo "Virtualenv missing at $VENV_PATH" >&2
@@ -11,6 +33,7 @@ if [ ! -d "$VENV_PATH" ]; then
 fi
 
 cd "$SCRIPT_DIR"
+# shellcheck disable=SC1091
 source "$VENV_PATH/bin/activate"
 EXTRA_PYTHONPATH="$SCRIPT_DIR/src"
 if [ -n "${PYTHONPATH:-}" ]; then
@@ -19,9 +42,15 @@ else
   export PYTHONPATH="$EXTRA_PYTHONPATH"
 fi
 
+echo $$ > "$PID_FILE"
+
 exec python -c "
-import sys
-from codex_plus.main_sync_cffi import app
-import uvicorn
-uvicorn.run(app, host='127.0.0.1', port=10000, log_level='info')
-"
+import sys, os
+try:
+    from codex_plus.main_sync_cffi import app
+    import uvicorn
+    uvicorn.run(app, host='127.0.0.1', port=10000, log_level='info')
+except Exception as exc:
+    print(f'STARTUP_ERROR: {exc}', file=sys.stderr)
+    sys.exit(1)
+" >> "$LOG_FILE" 2>> "$ERROR_LOG_FILE"

--- a/tests/test_proxy_launchd.py
+++ b/tests/test_proxy_launchd.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+import pytest
+import shlex
+import shutil
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "proxy.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+@pytest.mark.skipif(not SCRIPT_PATH.exists(), reason="proxy script missing")
+def test_proxy_enable_on_darwin_installs_launchd(tmp_path: Path) -> None:
+    repo_root = SCRIPT_PATH.parent
+    venv_path = repo_root / "venv"
+    created_venv = False
+    if not venv_path.exists():
+        (venv_path / "bin").mkdir(parents=True)
+        (venv_path / "bin" / "activate").write_text("#!/bin/bash\n")
+        created_venv = True
+
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_home = tmp_path / "home"
+    (fake_home / "Library" / "LaunchAgents").mkdir(parents=True)
+
+    launchctl_calls = runtime_dir / "launchctl_calls.log"
+
+    _write_executable(
+        fake_bin / "uname",
+        "#!/bin/bash\n"
+        "if [ \"${1:-}\" = \"-s\" ]; then\n"
+        "  echo Darwin\n"
+        "else\n"
+        "  echo Darwin\n"
+        "fi\n",
+    )
+
+    _write_executable(
+        fake_bin / "curl",
+        "#!/bin/bash\n"
+        "exit 0\n",
+    )
+
+    system_ps = shlex.quote(shutil.which("ps") or "/bin/ps")
+
+    _write_executable(
+        fake_bin / "ps",
+        "#!/bin/bash\n"
+        "if [ \"${1:-}\" = \"-p\" ]; then\n"
+        "  shift\n"
+        "  pid=$1\n"
+        "  shift\n"
+        "  if [ \"${1:-}\" = \"-o\" ] && [ \"${2:-}\" = \"command=\" ]; then\n"
+        "    echo python main_sync_cffi\n"
+        "    exit 0\n"
+        "  fi\n"
+        "fi\n"
+        f"exec {system_ps} \"$@\"\n",
+    )
+
+    _write_executable(
+        fake_bin / "launchctl",
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        f"echo \"$@\" >> {launchctl_calls}\n"
+        "runtime=\"${CODEX_PROXY_RUNTIME_DIR:-}\"\n"
+        "case \"${1:-}\" in\n"
+        "  start)\n"
+        "    proxy_script=\"${runtime}/main_sync_cffi_fake.sh\"\n"
+        "    if [ ! -f \"${proxy_script}\" ]; then\n"
+        "      cat <<'EOS' > \"${proxy_script}\"\n"
+        "#!/bin/bash\n"
+        "trap 'exit 0' TERM INT\n"
+        "while true; do\n"
+        "  sleep 1\n"
+        "done\n"
+        "EOS\n"
+        "      chmod +x \"${proxy_script}\"\n"
+        "    fi\n"
+        "    bash \"${proxy_script}\" &\n"
+        "    child=$!\n"
+        "    echo \"${child}\" > \"${runtime}/proxy.pid\"\n"
+        "    echo \"${child}\" > \"${runtime}/launched.pid\"\n"
+        "    ;;\n"
+        "  stop)\n"
+        "    if [ -f \"${runtime}/launched.pid\" ]; then\n"
+        "      child=$(cat \"${runtime}/launched.pid\")\n"
+        "      kill -TERM \"${child}\" >/dev/null 2>&1 || true\n"
+        "      rm -f \"${runtime}/launched.pid\"\n"
+        "    fi\n"
+        "    ;;\n"
+        "esac\n"
+        "exit 0\n",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "CODEX_PROXY_RUNTIME_DIR": str(runtime_dir),
+            "HOME": str(fake_home),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+        }
+    )
+    env.pop("CODEX_PROXY_GUARD_STATE", None)
+
+    result = subprocess.run(  # noqa: S603
+        ["bash", str(SCRIPT_PATH), "enable"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    try:
+        assert result.returncode == 0, result.stderr
+        assert "LaunchAgent installed" in result.stdout
+        assert "Proxy started successfully under launchd" in result.stdout
+
+        launch_agent_path = fake_home / "Library" / "LaunchAgents" / "com.codex.plus.proxy.plist"
+        assert launch_agent_path.exists()
+
+        launchd_env = runtime_dir / "launchd.env"
+        assert launchd_env.exists()
+        assert "CODEX_PLUS_PROVIDER_MODE=openai" in launchd_env.read_text()
+
+        error_log = runtime_dir / "proxy.err"
+        stdout_log = runtime_dir / "proxy.log"
+        launchd_stdout = runtime_dir / "launchd.out"
+        launchd_stderr = runtime_dir / "launchd.err"
+        for path in (error_log, stdout_log, launchd_stdout, launchd_stderr):
+            assert path.exists()
+
+        assert launchctl_calls.exists()
+        launchctl_output = launchctl_calls.read_text()
+        assert "load" in launchctl_output
+        assert "start" in launchctl_output
+    finally:
+        pid_file = runtime_dir / "proxy.pid"
+        if pid_file.exists():
+            try:
+                pid = int(pid_file.read_text().strip())
+            except ValueError:
+                pid = None
+            if pid:
+                os.kill(pid, signal.SIGTERM)
+        subprocess.run(  # noqa: S603
+            ["bash", str(SCRIPT_PATH), "disable"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if created_venv:
+            shutil.rmtree(venv_path)
+
+
+@pytest.mark.skipif(not SCRIPT_PATH.exists(), reason="proxy script missing")
+def test_proxy_help_lists_commands() -> None:
+    result = subprocess.run(  # noqa: S603
+        ["bash", str(SCRIPT_PATH), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    for command in ("enable", "disable", "start", "stop", "status", "restart", "autostart", "help"):
+        assert command in result.stdout


### PR DESCRIPTION
## Goal
- Add regression coverage for the launchd autostart workflow and CLI help output introduced for the proxy script.

## Modifications
- Added `tests/test_proxy_launchd.py` to simulate macOS launchd behaviour, verifying log creation, LaunchAgent provisioning, and success messaging when `./proxy.sh enable` runs on Darwin.
- Asserted that `./proxy.sh --help` enumerates all documented commands to keep CLI documentation in sync.

## Necessity
- The previous change ensured launchd autostart and logging, but lacked automated tests. The new tests lock down these expectations to avoid regressions.

## Integration Proof
- `pytest tests/test_proxy_launchd.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e692f74c4c832f8f798fdfa68d7bf9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances proxy startup on macOS via launchd with persisted env and split logs, adds CLI tweaks, and introduces tests covering launchd flow and help output.
> 
> - **Proxy/launchd (macOS)**:
>   - Persist environment to `RUNTIME_DIR/launchd.env` and load it in launchd runner; add helpers `prepare_runtime_paths`, `persist_launchd_environment`, `clear_launchd_environment`.
>   - Generate launchd runner script with injected paths/vars; write PID, use `PYTHONPATH`, and redirect stdout/err separately.
>   - Update install/start flow to use `launchctl` (load/start), wait for health, and handle failures; stop/uninstall clears env and unloads job.
> - **Logging**:
>   - Add error log `proxy.err`; split stdout/err for both foreground and launchd; add `launchd.out`/`launchd.err`; show Error Log in `status`.
> - **Process control**:
>   - Refine lock/cleanup; ensure lock removal on success; stronger port cleanup and PID validation.
> - **CLI**:
>   - Add `start`/`stop` aliases; extend `autostart` with `ensure`; update help text accordingly.
> - **Scripts**:
>   - Update `scripts/proxy_launchd.sh` to support runtime dir, PID file, env loading, and split logging.
> - **Tests**:
>   - Add `tests/test_proxy_launchd.py` simulating Darwin to verify launchd install/start, env/log artifacts, and `--help` command listing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b24a161b8615aecf74c7ae1625ba572380be36e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->