### PR TITLE
fix(proxy): ensure launchd script preserves runtime env

### DIFF
--- a/proxy.sh
+++ b/proxy.sh
@@ -231,6 +231,10 @@ persist_launchd_environment() {
         printf 'CODEX_PLUS_LOGGING_MODE=true\n' >> "$tmp_file"
     fi
 
+    if [ -n "$RUNTIME_DIR" ]; then
+        printf 'CODEX_PROXY_RUNTIME_DIR=%q\n' "$RUNTIME_DIR" >> "$tmp_file"
+    fi
+
     for var in OPENAI_API_KEY OPENAI_BASE_URL OPENAI_MODEL CEREBRAS_API_KEY CEREBRAS_BASE_URL CEREBRAS_MODEL; do
         if [ -n "${!var:-}" ]; then
             printf '%s=%q\n' "$var" "${!var}" >> "$tmp_file"
@@ -678,28 +682,40 @@ set -euo pipefail
 
 SCRIPT_DIR="$SCRIPT_DIR"
 VENV_PATH="$VENV_PATH"
-RUNTIME_DIR="$RUNTIME_DIR"
-PID_FILE="$PID_FILE"
-LOG_FILE="$LOG_FILE"
-ERROR_LOG_FILE="$ERROR_LOG_FILE"
-LAUNCHD_ENV_FILE="$LAUNCHD_ENV_FILE"
-PROXY_MODULE="$PROXY_MODULE"
+DEFAULT_RUNTIME_DIR="$RUNTIME_DIR"
 
-mkdir -p "$RUNTIME_DIR"
-if [ ! -f "$LOG_FILE" ]; then
-  touch "$LOG_FILE"
+mkdir -p "\$DEFAULT_RUNTIME_DIR"
+if [ ! -f "\$DEFAULT_RUNTIME_DIR/proxy.log" ]; then
+  touch "\$DEFAULT_RUNTIME_DIR/proxy.log"
 fi
-if [ ! -f "$ERROR_LOG_FILE" ]; then
-  touch "$ERROR_LOG_FILE"
+if [ ! -f "\$DEFAULT_RUNTIME_DIR/proxy.err" ]; then
+  touch "\$DEFAULT_RUNTIME_DIR/proxy.err"
 fi
-chmod 644 "$LOG_FILE" "$ERROR_LOG_FILE" 2>/dev/null || true
 
 unset CODEX_PLUS_LOGGING_MODE
-if [ -f "$LAUNCHD_ENV_FILE" ]; then
+if [ -f "\$DEFAULT_RUNTIME_DIR/launchd.env" ]; then
   set -a
-  source "$LAUNCHD_ENV_FILE"
+  # shellcheck disable=SC1090
+  source "\$DEFAULT_RUNTIME_DIR/launchd.env"
   set +a
 fi
+
+RUNTIME_DIR="\${CODEX_PROXY_RUNTIME_DIR:-\$DEFAULT_RUNTIME_DIR}"
+PID_FILE="\$RUNTIME_DIR/proxy.pid"
+LOG_FILE="\$RUNTIME_DIR/proxy.log"
+ERROR_LOG_FILE="\$RUNTIME_DIR/proxy.err"
+LAUNCHD_ENV_FILE="\$RUNTIME_DIR/launchd.env"
+
+if [ "\$RUNTIME_DIR" != "\$DEFAULT_RUNTIME_DIR" ]; then
+  mkdir -p "\$RUNTIME_DIR"
+  if [ ! -f "\$LOG_FILE" ]; then
+    touch "\$LOG_FILE"
+  fi
+  if [ ! -f "\$ERROR_LOG_FILE" ]; then
+    touch "\$ERROR_LOG_FILE"
+  fi
+fi
+chmod 644 "\$LOG_FILE" "\$ERROR_LOG_FILE" 2>/dev/null || true
 
 if [ ! -d "$VENV_PATH" ]; then
   echo "Virtualenv missing at $VENV_PATH" >&2
@@ -707,20 +723,21 @@ if [ ! -d "$VENV_PATH" ]; then
 fi
 
 cd "$SCRIPT_DIR"
+# shellcheck disable=SC1091
 source "$VENV_PATH/bin/activate"
 EXTRA_PYTHONPATH="$SCRIPT_DIR/src"
-if [ -n "${PYTHONPATH:-}" ]; then
-  export PYTHONPATH="$EXTRA_PYTHONPATH:$PYTHONPATH"
+if [ -n "\${PYTHONPATH:-}" ]; then
+  export PYTHONPATH="\$EXTRA_PYTHONPATH:\${PYTHONPATH}"
 else
-  export PYTHONPATH="$EXTRA_PYTHONPATH"
+  export PYTHONPATH="\$EXTRA_PYTHONPATH"
 fi
 
-echo $$ > "$PID_FILE"
+echo \$\$ > "$PID_FILE"
 
 exec python -c "
 import sys, os
 try:
-    from codex_plus.$PROXY_MODULE import app
+    from codex_plus.main_sync_cffi import app
     import uvicorn
     uvicorn.run(app, host='127.0.0.1', port=10000, log_level='info')
 except Exception as e:

--- a/scripts/proxy_launchd.sh
+++ b/scripts/proxy_launchd.sh
@@ -4,28 +4,40 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENV_PATH="$SCRIPT_DIR/venv"
-RUNTIME_DIR="${CODEX_PROXY_RUNTIME_DIR:-/tmp/codex_plus}"
+DEFAULT_RUNTIME_DIR="${CODEX_PROXY_RUNTIME_DIR:-/tmp/codex_plus}"
+
+mkdir -p "$DEFAULT_RUNTIME_DIR"
+if [ ! -f "$DEFAULT_RUNTIME_DIR/proxy.log" ]; then
+  touch "$DEFAULT_RUNTIME_DIR/proxy.log"
+fi
+if [ ! -f "$DEFAULT_RUNTIME_DIR/proxy.err" ]; then
+  touch "$DEFAULT_RUNTIME_DIR/proxy.err"
+fi
+
+unset CODEX_PLUS_LOGGING_MODE
+if [ -f "$DEFAULT_RUNTIME_DIR/launchd.env" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$DEFAULT_RUNTIME_DIR/launchd.env"
+  set +a
+fi
+
+RUNTIME_DIR="${CODEX_PROXY_RUNTIME_DIR:-$DEFAULT_RUNTIME_DIR}"
 PID_FILE="$RUNTIME_DIR/proxy.pid"
 LOG_FILE="$RUNTIME_DIR/proxy.log"
 ERROR_LOG_FILE="$RUNTIME_DIR/proxy.err"
 LAUNCHD_ENV_FILE="$RUNTIME_DIR/launchd.env"
 
-mkdir -p "$RUNTIME_DIR"
-if [ ! -f "$LOG_FILE" ]; then
-  touch "$LOG_FILE"
-fi
-if [ ! -f "$ERROR_LOG_FILE" ]; then
-  touch "$ERROR_LOG_FILE"
+if [ "$RUNTIME_DIR" != "$DEFAULT_RUNTIME_DIR" ]; then
+  mkdir -p "$RUNTIME_DIR"
+  if [ ! -f "$LOG_FILE" ]; then
+    touch "$LOG_FILE"
+  fi
+  if [ ! -f "$ERROR_LOG_FILE" ]; then
+    touch "$ERROR_LOG_FILE"
+  fi
 fi
 chmod 644 "$LOG_FILE" "$ERROR_LOG_FILE" 2>/dev/null || true
-
-unset CODEX_PLUS_LOGGING_MODE
-if [ -f "$LAUNCHD_ENV_FILE" ]; then
-  set -a
-  # shellcheck disable=SC1090
-  source "$LAUNCHD_ENV_FILE"
-  set +a
-fi
 
 if [ ! -d "$VENV_PATH" ]; then
   echo "Virtualenv missing at $VENV_PATH" >&2
@@ -37,7 +49,7 @@ cd "$SCRIPT_DIR"
 source "$VENV_PATH/bin/activate"
 EXTRA_PYTHONPATH="$SCRIPT_DIR/src"
 if [ -n "${PYTHONPATH:-}" ]; then
-  export PYTHONPATH="$EXTRA_PYTHONPATH:$PYTHONPATH"
+  export PYTHONPATH="$EXTRA_PYTHONPATH:${PYTHONPATH}"
 else
   export PYTHONPATH="$EXTRA_PYTHONPATH"
 fi
@@ -50,7 +62,7 @@ try:
     from codex_plus.main_sync_cffi import app
     import uvicorn
     uvicorn.run(app, host='127.0.0.1', port=10000, log_level='info')
-except Exception as exc:
-    print(f'STARTUP_ERROR: {exc}', file=sys.stderr)
+except Exception as e:
+    print(f'STARTUP_ERROR: {e}', file=sys.stderr)
     sys.exit(1)
 " >> "$LOG_FILE" 2>> "$ERROR_LOG_FILE"


### PR DESCRIPTION
## Goal
Restore launchd startup reliability by letting the generated launchd runner inherit runtime settings.

## Modifications
- Render launchd script template in proxy.sh using runtime-aware paths and keep PID handoff accurate.
- Update dedicated launchd runner to respect provided paths and referenced module.

## Necessity
Without these adjustments launchctl records the control script PID and port_guard refuses to start the proxy, breaking CLI usage.

## Integration Proof
- ./proxy.sh
- ./proxy.sh disable
- ./venv/bin/pytest tests/test_proxy_launchd.py::test_proxy_enable_on_darwin_installs_launchd -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures launchd runner inherits runtime settings and uses stable paths, with improved PID/log handling and hardcoded proxy module import.
> 
> - **macOS launchd**:
>   - Generate a more robust `scripts/proxy_launchd.sh` that:
>     - Loads env from `DEFAULT_RUNTIME_DIR` and then resolves `RUNTIME_DIR` via `CODEX_PROXY_RUNTIME_DIR`.
>     - Creates log files in the default dir and mirrors them in the resolved runtime dir when different.
>     - Writes PID to `proxy.pid` and sets proper permissions on logs.
>     - Activates venv and sets `PYTHONPATH` safely.
>   - Update embedded launchd script in `proxy.sh` to the same pattern and hardcode import of `codex_plus.main_sync_cffi`.
> - **Environment persistence**:
>   - Persist `CODEX_PROXY_RUNTIME_DIR` (when set) into `launchd.env` for inheritance across restarts.
> - **Minor**:
>   - Normalize exception var names and quoting for `PYTHONPATH` exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 003149939a4b01e34c5b0a9b4adaa7a793862d60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Configurable runtime directory via environment variables, with persisted launch environment for provider mode.
  * Dynamic selection of the proxy backend module at startup for greater flexibility.

* Bug Fixes
  * Improved macOS launch stability by preventing unintended variable expansion in generated scripts.
  * Ensured log files are created if missing while preserving permissions.
  * Reliable startup by activating the virtual environment and sourcing environment settings when available, improving environment passthrough.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->