### PR TITLE
fix(middleware): append status line instruction to response end

### DIFF
--- a/src/codex_plus/llm_execution_middleware.py
+++ b/src/codex_plus/llm_execution_middleware.py
@@ -36,7 +36,7 @@ import logging
 import os
 import asyncio
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Final
 import re
 from fastapi.responses import JSONResponse
 
@@ -45,7 +45,7 @@ from .chat_colorizer import apply_claude_colors
 logger = logging.getLogger(__name__)
 
 
-STATUS_LINE_INSTRUCTION_PREFIX = "Append this status line at the end of your response:"
+STATUS_LINE_INSTRUCTION_PREFIX: Final[str] = "Append this status line at the end of your response:"
 
 class LLMExecutionMiddleware:
     """Middleware that instructs LLM to execute slash commands like Claude Code CLI"""
@@ -272,7 +272,10 @@ BEGIN EXECUTION NOW:
                     for message in request_body["messages"]:
                         if message.get("role") == "user":
                             current_content = message.get("content", "")
-                            message["content"] = f"{current_content}\n\n{status_line_instruction}" if current_content else status_line_instruction
+                            if current_content:
+                                message["content"] = f"{current_content}\n\n{status_line_instruction}"
+                            else:
+                                message["content"] = status_line_instruction
                             break
 
                 logger.info("💉 Injected status line and/or execution instruction as system message")


### PR DESCRIPTION
## Goal
- Match the Claude Code CLI experience by rendering the git status line at the bottom of chat transcripts.

## Modifications
- Added a reusable status line instruction prefix and updated middleware injection to append the instruction after user text.
- Ensured Codex CLI and standard message payloads retain user content while appending the status line directive at the end.
- Updated status line injection tests to cover the new instruction text and ordering expectations.

## Necessity
- Previously, the instruction told the model to display the status line first, causing it to appear above the chat instead of below, diverging from the desired UX.

## Integration Proof
- `pytest tests/test_status_line_working_directory.py -k TestStatusLineInjection`


------
https://chatgpt.com/codex/tasks/task_e_68e7d6688328832fb2e95a304148ec80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes the status-line instruction prefix and appends it to the end of user prompts for both standard and Codex formats, updating tests accordingly.
> 
> - **Middleware (`src/codex_plus/llm_execution_middleware.py`)**:
>   - Introduces `STATUS_LINE_INSTRUCTION_PREFIX` and uses it for status-line injections.
>   - Changes status-line placement: appends `"Append this status line at the end of your response:" ...` after existing user content in both `messages` and `input` formats (preserving original text when present).
>   - Keeps execution instructions as system content, separate from visible status-line text.
>   - Minor typing: adds `Final`.
> - **Tests (`tests/test_status_line_working_directory.py`)**:
>   - Imports `STATUS_LINE_INSTRUCTION_PREFIX` and updates assertions to expect the new prefix and end-of-content placement.
>   - Verifies user content remains first and the status-line instruction is last in both formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a893e72e44f2d9022669cc7325d4efeb6793106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Standardized the prefix used for injected status-line instructions for consistent detection and placement across input formats.
- Improvements
  - Status lines are appended more reliably and predictably to prompts/messages without changing behavior.
  - Clearer separation between visible status lines and execution instructions for consistent rendering.
- Tests
  - Updated tests to validate the standardized prefix and its placement in both standard and Codex-style inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->