### PR TITLE
fix(middleware): fallback to home .claude commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Re-run `./install.sh` if you relocate the repo or switch shells, and double-chec
 - **Request logging:** `src/codex_plus/request_logger.py` captures structured payloads under `/tmp/codex_plus/<branch>/` for debugging and branch-specific auditing.
 - **Safety guardrails:** SSRF protection, header sanitization, and upstream validation run before forwarding to the ChatGPT backend.
 
-Explore `.codexplus/commands/` for ready-to-run slash commands like `/copilot`, `/echo`, `/hello`, and `/test-args`, and `.codexplus/hooks/` for Python hook samples with YAML/docstring metadata.
+Explore `.codexplus/commands/` for ready-to-run slash commands like `/copilot`, `/echo`, `/hello`, and `/test-args`, and `.codexplus/hooks/` for Python hook samples with YAML/docstring metadata. Running `./install.sh` now mirrors these commands into `~/.codexplus/commands/` and `~/.claude/commands/` so they remain available when you work inside other repositories (including `/reviewdeep`).
 
 ## Repository Tour
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Re-run `./install.sh` if you relocate the repo or switch shells, and double-chec
 - **Request logging:** `src/codex_plus/request_logger.py` captures structured payloads under `/tmp/codex_plus/<branch>/` for debugging and branch-specific auditing.
 - **Safety guardrails:** SSRF protection, header sanitization, and upstream validation run before forwarding to the ChatGPT backend.
 
-Explore `.codexplus/commands/` for ready-to-run slash commands like `/copilot`, `/echo`, `/hello`, and `/test-args`, and `.codexplus/hooks/` for Python hook samples with YAML/docstring metadata. Running `./install.sh` now mirrors these commands into `~/.codexplus/commands/` and `~/.claude/commands/` so they remain available when you work inside other repositories (including `/reviewdeep`).
+Explore `.codexplus/commands/` for ready-to-run slash commands like `/copilot`, `/echo`, `/hello`, and `/test-args`. You can also check `.codexplus/hooks/` for Python hook samples with YAML/docstring metadata. Running `./install.sh` now mirrors these commands into `~/.codexplus/commands/` and `~/.claude/commands/`. This ensures they remain available when you work inside other repositories (including `/reviewdeep`).
 
 ## Repository Tour
 

--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,17 @@ main() {
   rc_file="$(choose_shell_rc)"
   echo "Using shell configuration: $rc_file"
   append_snippet "$rc_file"
+
+  # Ensure users have slash command definitions available globally.
+  local python_cmd="python3"
+  if command -v "$python_cmd" >/dev/null 2>&1; then
+    if ! "$python_cmd" "${SCRIPT_DIR}/scripts/sync_commands.py" --include-defaults --quiet; then
+      echo "Warning: Failed to sync slash command files."
+    fi
+  else
+    echo "Warning: python3 not found; skipping slash command sync."
+  fi
+
   printf '\nNext steps:\n'
   echo "  1. source \"$rc_file\" (or restart your shell)."
   echo "  2. Run \"codex-plus-proxy enable\" to start the proxy (aliases to proxy.sh)."

--- a/scripts/sync_commands.py
+++ b/scripts/sync_commands.py
@@ -1,0 +1,94 @@
+"""Utility to sync slash command definitions into user command directories."""
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Iterable, List
+
+
+def sync_commands(source_dir: Path, destinations: Iterable[Path]) -> List[Path]:
+    """Copy markdown command files from ``source_dir`` into ``destinations``.
+
+    The directory structure beneath ``source_dir`` is preserved for each
+    destination. Files are copied when they are missing or when the contents
+    differ from the source version. Returns a list of destination files that
+    were created or updated.
+    """
+
+    if not source_dir.exists():
+        raise FileNotFoundError(f"Command source directory not found: {source_dir}")
+
+    updated: List[Path] = []
+    source_dir = source_dir.resolve()
+    command_files = sorted(p for p in source_dir.rglob("*.md") if p.is_file())
+
+    for source_file in command_files:
+        relative_path = source_file.relative_to(source_dir)
+        content = source_file.read_bytes()
+        for destination_root in destinations:
+            destination_root.mkdir(parents=True, exist_ok=True)
+            destination_file = (destination_root / relative_path).resolve()
+            destination_file.parent.mkdir(parents=True, exist_ok=True)
+
+            if not destination_file.exists() or destination_file.read_bytes() != content:
+                shutil.copy2(source_file, destination_file)
+                updated.append(destination_file)
+
+    return updated
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync slash command markdown files")
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / ".codexplus" / "commands",
+        help="Directory containing canonical command definitions.",
+    )
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        action="append",
+        dest="destinations",
+        help="Destination directory for synced commands (may be specified multiple times).",
+    )
+    parser.add_argument(
+        "--include-defaults",
+        action="store_true",
+        help="Include default destinations (~/.codexplus/commands and ~/.claude/commands).",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-file logging and only show a summary.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    destinations: List[Path] = []
+    if args.destinations:
+        destinations.extend(args.destinations)
+    if args.include_defaults or not destinations:
+        home = Path.home()
+        destinations.extend([
+            home / ".codexplus" / "commands",
+            home / ".claude" / "commands",
+        ])
+
+    updated_files = sync_commands(args.source, destinations)
+
+    if not args.quiet:
+        if updated_files:
+            print("Synced command files:")
+            for file_path in updated_files:
+                print(f" - {file_path}")
+        else:
+            print("Commands already up to date.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codex_plus/llm_execution_middleware.py
+++ b/src/codex_plus/llm_execution_middleware.py
@@ -104,7 +104,9 @@ class LLMExecutionMiddleware:
         search_roots = [self.codexplus_dir, self.home_codexplus_dir]
         if self.commands_dir:
             search_roots.append(self.commands_dir)
-        if self.home_claude_commands_dir and self.home_claude_commands_dir != self.commands_dir:
+        if self.home_claude_commands_dir and (
+            self.commands_dir is None or self.home_claude_commands_dir != self.commands_dir
+        ):
             search_roots.append(self.home_claude_commands_dir)
 
         for root in search_roots:

--- a/tests/test_sync_commands.py
+++ b/tests/test_sync_commands.py
@@ -7,7 +7,7 @@ SCRIPTS_DIR = REPO_ROOT / "scripts"
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.sync_commands import sync_commands  # noqa: E402
+from scripts.sync_commands import sync_commands
 
 
 def test_sync_commands_copies_reviewdeep(tmp_path):

--- a/tests/test_sync_commands.py
+++ b/tests/test_sync_commands.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+# Ensure scripts directory is importable
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.sync_commands import sync_commands  # noqa: E402
+
+
+def test_sync_commands_copies_reviewdeep(tmp_path):
+    source_dir = REPO_ROOT / ".codexplus" / "commands"
+    destination = tmp_path / ".claude" / "commands"
+
+    updated = sync_commands(source_dir, [destination])
+
+    reviewdeep_path = destination / "reviewdeep.md"
+    assert reviewdeep_path.exists()
+    assert reviewdeep_path.read_text(encoding="utf-8") == (
+        source_dir / "reviewdeep.md"
+    ).read_text(encoding="utf-8")
+    assert reviewdeep_path in updated


### PR DESCRIPTION
## Goal
- ensure slash command execution falls back to `~/.claude/commands` when project copies are missing

## Modifications
- extend `LLMExecutionMiddleware.find_command_file` lookup order to append the user `~/.claude/commands` directory after project-level `.claude`
- cache the home `.claude` command path during middleware initialization for reuse during lookups
- add a regression test confirming the fallback behavior when only the home `.claude` command exists

## Necessity
- without the fallback, slash commands defined only in `~/.claude/commands` are not discovered when invoked outside repositories that mirror them, preventing `/reviewdeep` and similar commands from running

## Integration Proof
- pytest tests/test_enhanced_slash_middleware_claude_dir.py -q


------
https://chatgpt.com/codex/tasks/task_e_68ebe3573638832fba9c270a85b8e819

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds user-level ~/.claude command fallback and an installer-driven command sync utility that mirrors project commands to home directories.
> 
> - **Middleware**:
>   - Extend `LLMExecutionMiddleware.find_command_file` search order to include `~/.claude/commands` after project `.claude/commands` and `.codexplus/commands`.
> - **Install/CLI**:
>   - Update `install.sh` to run `scripts/sync_commands.py --include-defaults --quiet` (with warnings on failure) to mirror commands to `~/.codexplus/commands` and `~/.claude/commands`.
>   - Add `scripts/sync_commands.py` to copy `*.md` from `.codexplus/commands` to user command dirs, preserving structure and updating only when contents differ.
> - **Tests**:
>   - Add fallback test ensuring resolution from `~/.claude/commands` when no project directory exists.
>   - Add syncing test verifying `reviewdeep.md` is copied to destination.
> - **Docs**:
>   - Update `README.md` to note global mirroring of commands during installation and persistent availability across repositories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 411b2f33ac80f3e50120c0a0f0cca6212a7dc05e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Installer now attempts to synchronize command definitions into user command directories for global availability; logs warnings if syncing is skipped or fails.
  - Command discovery now includes user-level Claude commands as a final fallback, with refined search precedence between project and home locations.

- Documentation
  - README updated to describe persistent command availability across repositories.

- Tests
  - Added tests for the sync behavior and the home-directory fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->