### PR TITLE
fix(middleware): ensure home claude slash fallback

### DIFF
--- a/src/codex_plus/llm_execution_middleware.py
+++ b/src/codex_plus/llm_execution_middleware.py
@@ -54,26 +54,36 @@ class LLMExecutionMiddleware:
 
     def __init__(self, upstream_url: str):
         self.upstream_url = upstream_url
-        self.claude_dir = self._find_claude_dir()
-        self.commands_dir = self.claude_dir / "commands" if self.claude_dir else None
+        self.project_claude_dir = self._find_project_claude_dir()
+        self.project_commands_dir = (
+            self.project_claude_dir / "commands" if self.project_claude_dir else None
+        )
+        self.home_claude_dir = self._get_home_claude_dir()
+        self.home_commands_dir = (
+            self.home_claude_dir / "commands" if self.home_claude_dir else None
+        )
         self.codexplus_dir = Path(".codexplus/commands")
         self.home_codexplus_dir = Path.home() / ".codexplus" / "commands"
         self._retry_schedule = self._RETRY_DELAYS
-        
-    def _find_claude_dir(self) -> Optional[Path]:
-        """Find .claude directory in project hierarchy"""
+
+    def _find_project_claude_dir(self) -> Optional[Path]:
+        """Find project-local .claude directory in current hierarchy"""
         current = Path.cwd()
         while current != current.parent:
             claude_dir = current / ".claude"
             if claude_dir.exists():
                 return claude_dir
             current = current.parent
-        
+
+        return None
+
+    def _get_home_claude_dir(self) -> Optional[Path]:
+        """Return ~/.claude directory when it exists"""
         # Check in home directory as fallback
         home_claude = Path.home() / ".claude"
         if home_claude.exists():
             return home_claude
-        
+
         return None
     
     def detect_slash_commands(self, text: str) -> List[Tuple[str, str]]:
@@ -104,10 +114,13 @@ class LLMExecutionMiddleware:
         return commands
     
     def find_command_file(self, command_name: str) -> Optional[Path]:
-        """Locate command definition with local .codexplus, home ~/.codexplus, then .claude."""
-        search_roots = [self.codexplus_dir, self.home_codexplus_dir]
-        if self.commands_dir:
-            search_roots.append(self.commands_dir)
+        """Locate command definition in local/home .codexplus then project/home .claude."""
+        search_roots = [
+            self.codexplus_dir,
+            self.home_codexplus_dir,
+            self.project_commands_dir,
+            self.home_commands_dir,
+        ]
 
         for root in search_roots:
             if not root or not root.exists():

--- a/src/codex_plus/llm_execution_middleware.py
+++ b/src/codex_plus/llm_execution_middleware.py
@@ -116,10 +116,14 @@ class LLMExecutionMiddleware:
     def find_command_file(self, command_name: str) -> Optional[Path]:
         """Locate command definition in local/home .codexplus then project/home .claude."""
         search_roots = [
-            self.codexplus_dir,
-            self.home_codexplus_dir,
-            self.project_commands_dir,
-            self.home_commands_dir,
+            root
+            for root in (
+                self.codexplus_dir,
+                self.home_codexplus_dir,
+                self.project_commands_dir,
+                self.home_commands_dir,
+            )
+            if root is not None
         ]
 
         for root in search_roots:


### PR DESCRIPTION
## Goal
- Guarantee slash command resolution eventually checks `~/.claude/commands` even when a project-level `.claude` directory exists.

## Modifications
- Split project and home `.claude` discovery so both command directories can be checked.
- Expand slash command search order to include project `.claude/commands` ahead of the new home fallback.
- Added regression test covering the `~/.claude/commands` fallback when a project `.claude` lacks a command.

## Necessity
- Without the additional fallback, users with both project and home `.claude` directories could not invoke commands that only live in `~/.claude/commands`.

## Integration Proof
- `pytest tests/test_enhanced_slash_middleware_claude_dir.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ec44a4fd0c832f9abfa090af820a86

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures slash commands fall back to ~/.claude/commands when not found in project .claude by splitting project/home discovery and updating search order.
> 
> - **Middleware** (`src/codex_plus/llm_execution_middleware.py`):
>   - Split `.claude` discovery into `project` and `home` (`_find_project_claude_dir`, `_get_home_claude_dir`).
>   - Updated search order in `find_command_file` to: local `.codexplus/commands`, home `.codexplus/commands`, project `.claude/commands`, then home `.claude/commands`.
> - **Tests** (`tests/test_enhanced_slash_middleware_claude_dir.py`):
>   - Added regression test verifying fallback to `~/.claude/commands` when project `.claude` lacks the command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9262dcbbe87a8ee801d2ccdc4c96065c1dd43a16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded command discovery to search both project-level and home-level .claude directories, alongside existing locations.
  - Adds clear fallback behavior: if a command isn’t found in the project’s .claude/commands, it will resolve from the user’s ~/.claude/commands when available.
  - Search order updated to prefer project-local commands then home commands.

- **Tests**
  - Added a test verifying fallback to home-level commands when project-level match is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->