### PR TITLE
fix: scope slash commands to latest user message

### DIFF
--- a/src/codex_plus/llm_execution_middleware.py
+++ b/src/codex_plus/llm_execution_middleware.py
@@ -268,10 +268,12 @@ BEGIN EXECUTION NOW:
                 # Add status line instruction directly to user message
                 if status_line_instruction:
                     for message in reversed(request_body["messages"]):
-                        if message.get("role") == "user":
-                            current_content = message.get("content", "")
-                            message["content"] = f"{status_line_instruction}\n\n{current_content}"
-                            break
+                        if message.get("role") != "user":
+                            continue
+
+                        current_content = message.get("content", "")
+                        message["content"] = f"{status_line_instruction}\n\n{current_content}"
+                        break
 
                 logger.info("💉 Injected status line and/or execution instruction as system message")
 

--- a/src/codex_plus/llm_execution_middleware.py
+++ b/src/codex_plus/llm_execution_middleware.py
@@ -220,12 +220,13 @@ BEGIN EXECUTION NOW:
         
         # Handle standard format with messages field
         elif "messages" in request_body:
-            for message in request_body["messages"]:
+            for message in reversed(request_body["messages"]):
                 if message.get("role") == "user" and "content" in message:
                     text = message["content"]
                     detected = self.detect_slash_commands(text)
                     if detected:
                         commands.extend(detected)
+                    break
         
         # Build injection content
         injection_parts = []
@@ -266,7 +267,7 @@ BEGIN EXECUTION NOW:
 
                 # Add status line instruction directly to user message
                 if status_line_instruction:
-                    for message in request_body["messages"]:
+                    for message in reversed(request_body["messages"]):
                         if message.get("role") == "user":
                             current_content = message.get("content", "")
                             message["content"] = f"{status_line_instruction}\n\n{current_content}"


### PR DESCRIPTION
## Goal
- prevent historical slash commands from being re-executed when a status line is injected

## Modifications
- limit slash command detection to the newest user message in standard chat payloads
- inject the status line into the latest user message instead of the first one encountered
- add a regression test ensuring only the latest command drives execution instructions

## Necessity
- resolves a regression where Codex+ would ignore the most recent command or repeat earlier ones when a status line was present

## Integration Proof
- ✅ `pytest tests/test_llm_execution.py`


------
https://chatgpt.com/codex/tasks/task_e_68ec45e77874832f958c11d7bd943350

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limit slash command detection and status line injection to the most recent user message, with a regression test ensuring only the latest command drives execution.
> 
> - **Middleware (`src/codex_plus/llm_execution_middleware.py`)**:
>   - Slash command detection now scans `messages` in reverse to target the latest `user` message and stops after first detection.
>   - Status line injection now prepends to the latest `user` message by iterating `messages` in reverse.
> - **Tests (`tests/test_llm_execution.py`)**:
>   - Add regression test `test_status_line_only_applies_to_latest_user_command` verifying only the newest command influences system instructions and status line placement.
>   - Minor setup: import `SimpleNamespace` for test state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a965d3c1a4e897816ad9adfb8509591a4bce7a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slash command detection and status line application now target the most recent user message, ensuring the latest command is applied while earlier messages stay unchanged.

* **Tests**
  * Added a test verifying that the status line and command detection apply only to the latest user message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->