### PR TITLE
fix: show status line at end of chat replies

### DIFF
--- a/tests/test_status_line_working_directory.py
+++ b/tests/test_status_line_working_directory.py
@@ -236,10 +236,12 @@ class TestStatusLineInjection:
         modified_body = llm_middleware.inject_execution_behavior(request_body)
 
         # Assert
-        # Should contain status line instruction
+        # Should contain status line instruction appended after the user text
         input_text = modified_body["input"][0]["content"][0]["text"]
-        assert "Display this status line first:" in input_text
+        instruction_prefix = "Append this status line as the final line of your response:"
         assert "test_repo" in input_text
+        assert input_text.startswith("test command")
+        assert input_text.splitlines()[-1].startswith(instruction_prefix)
 
     def test_status_line_injection_into_standard_format(self, llm_middleware, mock_request_with_working_dir):
         """FAILING: Should inject status line into standard messages format"""
@@ -266,8 +268,10 @@ class TestStatusLineInjection:
                 break
 
         assert user_message is not None
-        assert "Display this status line first:" in user_message["content"]
+        instruction_prefix = "Append this status line as the final line of your response:"
         assert "test_repo" in user_message["content"]
+        assert user_message["content"].startswith("test message")
+        assert user_message["content"].splitlines()[-1].startswith(instruction_prefix)
 
 
 class TestGitHeaderScriptResolution:


### PR DESCRIPTION
## Goal
Ensure the Codex Plus proxy renders the git status line at the bottom of each Claude conversation, matching the Claude Code CLI layout.

## Modifications
- Adjusted the execution middleware to append the status line instruction after the user message so Claude renders it as the final line of a reply.
- Updated status line unit tests to assert the instruction appears after the user content in both Codex CLI and standard message payloads.

## Necessity
Claude previously displayed the status line at the top of the transcript, which diverged from the Claude Code CLI experience the proxy emulates. Appending the instruction restores the expected placement and avoids confusing prompt preambles.

## Integration Proof
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e7d6688328832fb2e95a304148ec80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches status line injection to append an instruction suffix so replies end with the status line, updating tests accordingly.
> 
> - **Middleware (`src/codex_plus/llm_execution_middleware.py`)**
>   - Introduces `STATUS_LINE_INSTRUCTION_PREFIX` and helper `_append_status_line`.
>   - Changes injection to append status line instruction to user content (last line) instead of prefixing.
>   - Adjusts detection from "Display this status line first:" to the new prefix.
> - **Tests (`tests/test_status_line_working_directory.py`)**
>   - Updates assertions to expect original content first and status line instruction as the final line.
>   - Imports and uses `STATUS_LINE_INSTRUCTION_PREFIX` for consistent checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ebd592cd1217e23727203ce059e4c9a5ddda38f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Standardized status-line instruction text and handling across formats.
  - Status line is now appended as the final line of responses (instead of shown first).
  - Preserves existing message content and inserts the status line when content is empty.
  - Keeps system-level execution instructions and cross-format compatibility.

- Tests
  - Updated assertions to match the new final-line placement and phrasing.
  - Verifies responses begin with original content and end with the status-line instruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->